### PR TITLE
Deep copy improvements

### DIFF
--- a/TabletopTweaks/Utilities/Helpers.cs
+++ b/TabletopTweaks/Utilities/Helpers.cs
@@ -254,6 +254,13 @@ namespace TabletopTweaks.Utilities {
                 }
                 public override int GetHashCode(object obj) {
                     if (obj == null) return 0;
+                    if (obj is WeakResourceLink wrl) {
+                        if (wrl.AssetId == null) {
+                            return "WeakResourceLink".GetHashCode();
+                        } else {
+                            return wrl.GetHashCode();
+                        }
+                    }
                     return obj.GetHashCode();
                 }
             }
@@ -270,6 +277,7 @@ namespace TabletopTweaks.Utilities {
                 if (originalObject == null) return null;
                 var typeToReflect = originalObject.GetType();
                 if (IsPrimitive(typeToReflect)) return originalObject;
+                if (originalObject is BlueprintReferenceBase) return originalObject;
                 if (visited.ContainsKey(originalObject)) return visited[originalObject];
                 if (typeof(Delegate).IsAssignableFrom(typeToReflect)) return null;
                 var cloneObject = CloneMethod.Invoke(originalObject, null);


### PR DESCRIPTION
Added checks to prevent deep copying nested blueprints which causes crashes; also added a special case in GetHashCode for WeakResourceLink, since its GetHashCode does not handle null AssetIds gracefully. It might be better to encode the type into the visited dictionary key, since I suspect the current approach might lead to incompatible types with colliding hashes, in particular 0.

The "WeakResourceLink".GetHashCode() as a hash for the WeakResourceLink with a null asset id was done because using the more common 0 caused issues, possibly... likely... due to hash collision.