### PR TITLE
Fix char creation result screen nullreference

### DIFF
--- a/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
+++ b/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
@@ -127,16 +127,15 @@ namespace TabletopTweaks.NewUnitParts {
         }
 
         public void AddImmunity(EntityFact fact, BlueprintComponent component, DamageEnergyType type) {
+            this.TryInitialize();
             if (this.m_Immunities.FirstItem<TTUnitPartDamageReduction.Immunity>(i => i.SourceFact == fact && i.SourceComponent == component) != null)
                 PFLog.Default.Error("UnitPartDamageReduction.AddImmunity: can't add immunity twice {0}.{1}", fact.Blueprint.name, component.name);
             else
                 this.m_Immunities.Add(new TTUnitPartDamageReduction.Immunity(fact, component, type));
-            RecalculateChunkStacks();
         }
 
         public void RemoveImmunity(EntityFact fact, BlueprintComponent component) {
             this.m_Immunities.RemoveAll(i => i.SourceFact == fact && i.SourceComponent == component);
-            RecalculateChunkStacks();
             this.RemovePartIfNecessary();
         }
 

--- a/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
+++ b/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
@@ -131,10 +131,12 @@ namespace TabletopTweaks.NewUnitParts {
                 PFLog.Default.Error("UnitPartDamageReduction.AddImmunity: can't add immunity twice {0}.{1}", fact.Blueprint.name, component.name);
             else
                 this.m_Immunities.Add(new TTUnitPartDamageReduction.Immunity(fact, component, type));
+            RecalculateChunkStacks();
         }
 
         public void RemoveImmunity(EntityFact fact, BlueprintComponent component) {
             this.m_Immunities.RemoveAll(i => i.SourceFact == fact && i.SourceComponent == component);
+            RecalculateChunkStacks();
             this.RemovePartIfNecessary();
         }
 

--- a/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
+++ b/TabletopTweaks/NewUnitParts/TTUnitPartDamageReduction.cs
@@ -60,6 +60,8 @@ namespace TabletopTweaks.NewUnitParts {
 
         public IEnumerable<ReductionDisplay> AllSources {
             get {
+                if (m_ChunkStacks == null)
+                    RecalculateChunkStacks();
                 // Populate sources display list
                 m_ChunkStacksForDisplay = new List<ChunkStack>();
                 for (int i = 0; i < m_ChunkStacks.Length; i++) {


### PR DESCRIPTION
Original report was that it was not possible to create a Dhamphir character, as the Result screen would be blank and the Next button disabled.

When a character would gain an Immunity before gaining any resistances or DR, the TTUnitPartDamageReduction unit part would be created but not initialized properly, leaving m_ChunkStacks null. This would cause anything that called AllSources to crash on a NullReferenceException. Dhampirs gain Immunity to Negative Energy on character creation.

Two fixes were implemented (there's a bit of better-safe-than-sorry-redundancy here):
- AddImmunity will properly call TryInitialize before doing anything (this should really be enough)
- An explicit check on m_ChunkStacks == null was added at the start of the AllSources getter, calling RecalculateChunkStacks() if it's true (although this *should* no longer happen due to the first fix).