### PR TITLE
Fix Paladin Mount's busted Celestial Template

### DIFF
--- a/TabletopTweaks/Bugfixes/Classes/Paladin.cs
+++ b/TabletopTweaks/Bugfixes/Classes/Paladin.cs
@@ -1,5 +1,10 @@
 ﻿using HarmonyLib;
+using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.JsonSystem;
+using Kingmaker.Designers.Mechanics.Facts;
+using System;
+using System.Linq;
 
 namespace TabletopTweaks.Bugfixes.Classes {
     class Paladin {
@@ -11,9 +16,24 @@ namespace TabletopTweaks.Bugfixes.Classes {
                 if (Initialized) return;
                 Initialized = true;
                 Main.LogHeader("Patching Paladin");
+                PatchBase();
             }
             static void PatchBase() {
+
+
+                PatchDivineMount();
+                void PatchDivineMount() {
+                    BlueprintFeature TemplateCelestial = Resources.GetModBlueprint<BlueprintFeature>("TemplateCelestial");
+                    BlueprintFeature PaladinMount2Celestial = Resources.GetBlueprint<BlueprintFeature>("ea31185f4e0f91041bf766d67214182f");
+                    AddFeatureToPet addFeatureToPet = PaladinMount2Celestial.Components.OfType<AddFeatureToPet>().FirstOrDefault();
+                    if (addFeatureToPet != null) {
+                        addFeatureToPet.m_Feature = TemplateCelestial.ToReference<BlueprintFeatureReference>();
+                    }
+                    
+                }
+
             }
+
             static void PatchArchetypes() {
             }
         }


### PR DESCRIPTION
Owlcat screwed up on giving Paladin Mounts the celestial template propely at level 11 - lots of textless features, no smite evil, and sr is busted.

Your Celestial template from Divine Commander works like a charm.

Applied it to the pally mount as well.