### PR TITLE
fix expanded arsenal when you have spell focus in the same school

### DIFF
--- a/TabletopTweaks/Config/Fixes.json
+++ b/TabletopTweaks/Config/Fixes.json
@@ -350,7 +350,8 @@
         "DisableAll": false,
         "Enabled": {
             "ExtraFeat": true,
-            "ExtraMythicAbility": true
+            "ExtraMythicAbility": true,
+            "ExpandedArsenal": true
         }
     },
     "Items": {


### PR DESCRIPTION
Expanded Arsenal only works if the chosen school doesn't already have a qualifying feat.

Good explanation of issue here: https://www.reddit.com/r/Pathfinder_Kingmaker/comments/pjvjiq/wotr_expanded_arsenal_magic_school_what_is_that/