### PR TITLE
Changes to magical tail to get rid of sleep abilities

### DIFF
--- a/TabletopTweaks/Bugfixes/Features/Feats.cs
+++ b/TabletopTweaks/Bugfixes/Features/Feats.cs
@@ -15,6 +15,7 @@ using Kingmaker.RuleSystem;
 using Kingmaker.RuleSystem.Rules;
 using Kingmaker.RuleSystem.Rules.Damage;
 using Kingmaker.UnitLogic.Abilities;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Abilities.Components;
 using Kingmaker.UnitLogic.Buffs.Blueprints;
 using Kingmaker.UnitLogic.FactLogic;
@@ -60,6 +61,102 @@ namespace TabletopTweaks.Bugfixes.Features {
                 PatchSlashingGrace();
                 PatchSpiritedCharge();
                 PatchWeaponFinesse();
+                PatchMagicalTail();
+            }
+            static void PatchMagicalTail() {
+                if (ModSettings.Fixes.Feats.IsDisabled("MagicalTail")) { return; }
+
+                BlueprintFeature magicalTail1 = Resources.GetBlueprint<BlueprintFeature>("5114829572da5a04f896a8c5b67be413");
+                BlueprintFeature magicalTail2 = Resources.GetBlueprint<BlueprintFeature>("c032f65c0bd9f6048a927fb07fc0195d"); // Abilities change for this one
+                BlueprintFeature magicalTail3 = Resources.GetBlueprint<BlueprintFeature>("d5050e13742d9b64da20921aaf7c2b2a");
+                BlueprintFeature magicalTail4 = Resources.GetBlueprint<BlueprintFeature>("342b6aed6b2eaab4786de243f0bcbcb8");
+                BlueprintFeature magicalTail5 = Resources.GetBlueprint<BlueprintFeature>("044cd84818c36854abf61064ade542a1"); // Abilites change for this one
+                BlueprintFeature magicalTail6 = Resources.GetBlueprint<BlueprintFeature>("053e37697a0d20547b06c3dbd8b71702");
+                BlueprintFeature magicalTail7 = Resources.GetBlueprint<BlueprintFeature>("041f91c25586d48469dce6b4575053f6");
+                BlueprintFeature magicalTail8 = Resources.GetBlueprint<BlueprintFeature>("df186ef345849d149bdbf4ddb45aee35");
+
+                BlueprintAbility sleepKitsune = Resources.GetBlueprint<BlueprintAbility>("f8a32c60ae1f878408b525bb967ef48c");
+                BlueprintAbility hideousLaughter = Resources.GetBlueprint<BlueprintAbility>("fd4d9fd7f87575d47aafe2a64a6e2d8d");
+
+                BlueprintAbility deepSlumberKitsune = Resources.GetBlueprint<BlueprintAbility>("2bc8d4bb8baa23a4b84ef34945d13733");
+                BlueprintAbility heroism = Resources.GetBlueprint<BlueprintAbility>("5ab0d42fb68c9e34abae4921822b9d63");
+
+                var hideousLaughterKitsune = Helpers.CreateCopy(hideousLaughter, bp => {
+                    bp.AssetGuid = ModSettings.Blueprints.GetGUID("HideousLaughterKitsune");
+                });
+                
+                hideousLaughterKitsune.RemoveComponents<AbilityResourceLogic>();
+                hideousLaughterKitsune.AddComponent<AbilityResourceLogic>(c => {
+                    c.Amount = sleepKitsune.GetComponent<AbilityResourceLogic>().Amount;
+                    c.CostIsCustom = sleepKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
+                    c.m_IsSpendResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
+                    c.m_RequiredResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
+                    c.name = sleepKitsune.GetComponent<AbilityResourceLogic>().name;
+                    c.ResourceCostDecreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
+                    c.ResourceCostIncreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
+                });
+                
+                Resources.AddBlueprint(hideousLaughterKitsune);
+
+                var heroismKitsune = Helpers.CreateCopy(heroism, bp => {
+                    bp.AssetGuid = ModSettings.Blueprints.GetGUID("HeroismKitsune");
+                });
+
+                heroismKitsune.RemoveComponents<AbilityResourceLogic>();
+                heroismKitsune.AddComponent<AbilityResourceLogic>(c => {
+                    c.Amount = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().Amount;
+                    c.CostIsCustom = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
+                    c.m_IsSpendResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
+                    c.m_RequiredResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
+                    c.name = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().name;
+                    c.ResourceCostDecreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
+                    c.ResourceCostIncreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
+                });
+
+                Resources.AddBlueprint(heroismKitsune);
+
+                var magicalTailDescription = "You gain a new {g|Encyclopedia:Special_Abilities}spell-like ability{/g}, each usable twice per day," +
+                                             " from the following list, in order:\n1. vanish\n2. hideous laughter\n3. blur\n4. invisibility\n5. heroism\n6." +
+                                             " displacement\n7. confusion\n8. dominate person.\nFor example, the first time you select this {g|Encyclopedia:Feat}feat{/g}," +
+                                             " you gain vanish 2/day; the second time you select this feat, you gain hideous laughter 2/day. Your {g|Encyclopedia:Caster_Level}caster level{/g}" +
+                                             " for these {g|Encyclopedia:Spell}spells{/g} is equal to your {g|Encyclopedia:Hit_Dice}Hit Dice{/g}. The DCs for these abilities are" +
+                                             " {g|Encyclopedia:Charisma}Charisma{/g}-based.\nYou may select this feat up to eight times. Each time you take it, you gain an additional ability as described above.";
+               
+                magicalTail1.SetDescription(magicalTailDescription);
+                magicalTail2.SetDescription(magicalTailDescription);
+                magicalTail3.SetDescription(magicalTailDescription);
+                magicalTail4.SetDescription(magicalTailDescription);
+                magicalTail5.SetDescription(magicalTailDescription);
+                magicalTail6.SetDescription(magicalTailDescription);
+                magicalTail7.SetDescription(magicalTailDescription);
+                magicalTail8.SetDescription(magicalTailDescription);
+
+                BlueprintFeature v = new BlueprintFeature();
+
+                magicalTail2.RemoveComponents<AddFacts>();
+
+                magicalTail2.AddComponent<AddFacts>(c => {
+                    c.m_Facts = new BlueprintUnitFactReference[] {
+                    hideousLaughterKitsune.ToReference<BlueprintUnitFactReference>()
+                };
+                });
+
+                magicalTail5.RemoveComponents<AddFacts>();
+
+                magicalTail5.AddComponent<AddFacts>(c => {
+                    c.m_Facts = new BlueprintUnitFactReference[] {
+                    heroismKitsune.ToReference<BlueprintUnitFactReference>()
+                };
+                });
+
+                Main.LogPatch("Patched", magicalTail1);
+                Main.LogPatch("Patched", magicalTail2);
+                Main.LogPatch("Patched", magicalTail3);
+                Main.LogPatch("Patched", magicalTail4);
+                Main.LogPatch("Patched", magicalTail5);
+                Main.LogPatch("Patched", magicalTail6);
+                Main.LogPatch("Patched", magicalTail7);
+                Main.LogPatch("Patched", magicalTail8);
             }
 
             static void PatchCraneWing() {

--- a/TabletopTweaks/Bugfixes/Features/Feats.cs
+++ b/TabletopTweaks/Bugfixes/Features/Feats.cs
@@ -75,45 +75,8 @@ namespace TabletopTweaks.Bugfixes.Features {
                 BlueprintFeature magicalTail7 = Resources.GetBlueprint<BlueprintFeature>("041f91c25586d48469dce6b4575053f6");
                 BlueprintFeature magicalTail8 = Resources.GetBlueprint<BlueprintFeature>("df186ef345849d149bdbf4ddb45aee35");
 
-                BlueprintAbility sleepKitsune = Resources.GetBlueprint<BlueprintAbility>("f8a32c60ae1f878408b525bb967ef48c");
-                BlueprintAbility hideousLaughter = Resources.GetBlueprint<BlueprintAbility>("fd4d9fd7f87575d47aafe2a64a6e2d8d");
-
-                BlueprintAbility deepSlumberKitsune = Resources.GetBlueprint<BlueprintAbility>("2bc8d4bb8baa23a4b84ef34945d13733");
-                BlueprintAbility heroism = Resources.GetBlueprint<BlueprintAbility>("5ab0d42fb68c9e34abae4921822b9d63");
-
-                var hideousLaughterKitsune = Helpers.CreateCopy(hideousLaughter, bp => {
-                    bp.AssetGuid = ModSettings.Blueprints.GetGUID("HideousLaughterKitsune");
-                });
-                
-                hideousLaughterKitsune.RemoveComponents<AbilityResourceLogic>();
-                hideousLaughterKitsune.AddComponent<AbilityResourceLogic>(c => {
-                    c.Amount = sleepKitsune.GetComponent<AbilityResourceLogic>().Amount;
-                    c.CostIsCustom = sleepKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
-                    c.m_IsSpendResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
-                    c.m_RequiredResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
-                    c.name = sleepKitsune.GetComponent<AbilityResourceLogic>().name;
-                    c.ResourceCostDecreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
-                    c.ResourceCostIncreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
-                });
-                
-                Resources.AddBlueprint(hideousLaughterKitsune);
-
-                var heroismKitsune = Helpers.CreateCopy(heroism, bp => {
-                    bp.AssetGuid = ModSettings.Blueprints.GetGUID("HeroismKitsune");
-                });
-
-                heroismKitsune.RemoveComponents<AbilityResourceLogic>();
-                heroismKitsune.AddComponent<AbilityResourceLogic>(c => {
-                    c.Amount = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().Amount;
-                    c.CostIsCustom = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
-                    c.m_IsSpendResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
-                    c.m_RequiredResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
-                    c.name = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().name;
-                    c.ResourceCostDecreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
-                    c.ResourceCostIncreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
-                });
-
-                Resources.AddBlueprint(heroismKitsune);
+                var hideousLaughterKitsune = Resources.GetModBlueprint<BlueprintAbility>("HideousLaughterKitsune");
+                var heroismKitsune = Resources.GetModBlueprint<BlueprintAbility>("HeroismKitsune");
 
                 var magicalTailDescription = "You gain a new {g|Encyclopedia:Special_Abilities}spell-like ability{/g}, each usable twice per day," +
                                              " from the following list, in order:\n1. vanish\n2. hideous laughter\n3. blur\n4. invisibility\n5. heroism\n6." +

--- a/TabletopTweaks/Config/Blueprints.json
+++ b/TabletopTweaks/Config/Blueprints.json
@@ -260,6 +260,8 @@
         "HalflingUnderfootFeature": "bf9721a0-fb98-4882-9929-46689e53b253",
         "HellknightSigniferChannelerOfTheUnknownLevelUp": "e0f2a5a3-d017-4d4f-b703-5e948fadedf9",
         "HellknightSigniferChannelerOfTheUnknownProgression": "5007dfc5-0983-4d8a-92ef-ca797b93ffed",
+        "HideousLaughterKitsune": "5bdc16d6-e363-4854-8223-c6384e711848",
+        "HeroismKitsune": "bb6220a9-5c84-4b38-ae94-2b856a65bceb",
         "ImpossibleSpeedFeature": "318b7e1a-cbce-4c02-a4a2-9d8953154d84",
         "ImprovedChannel": "8fe243b4-a9ab-4830-a7ad-40a9c20a35ea",
         "LongArmAbility": "fde4d2da-3043-45bc-a11a-73eb8f06b755",

--- a/TabletopTweaks/Config/Fixes.json
+++ b/TabletopTweaks/Config/Fixes.json
@@ -589,6 +589,11 @@
                 "Enabled": true,
                 "Description": "Now works correctly."
             },
+            "MagicalTail": {
+                "Enabled": true,
+                "Homebrew": true,
+                "Description": "Magical Tail gives Hideous Laughter at 2 and Heroism at 5 instead of sleep spells."
+            },
             "MaximizeMetamagic": {
                 "Enabled": true,
                 "Description": "Allows sticky touch spells to be maximized."

--- a/TabletopTweaks/NewContent/ContentAdder.cs
+++ b/TabletopTweaks/NewContent/ContentAdder.cs
@@ -85,7 +85,7 @@ namespace TabletopTweaks.NewContent {
 
                 Spells.LongArms.AddLongArms();
                 Spells.ShadowEnchantment.AddShadowEnchantment();
-                Spells.ShadowEnchantment.AddShadowEnchantmentGreater();
+                Spells.MagicalTailSpells.AddNewMagicalTailSpells();
 
                 MythicAbilities.ImpossibleSpeed.AddImpossibleSpeed();
                 MythicAbilities.ArmorMaster.AddArmorMaster();

--- a/TabletopTweaks/NewContent/ContentAdder.cs
+++ b/TabletopTweaks/NewContent/ContentAdder.cs
@@ -85,6 +85,7 @@ namespace TabletopTweaks.NewContent {
 
                 Spells.LongArms.AddLongArms();
                 Spells.ShadowEnchantment.AddShadowEnchantment();
+                Spells.ShadowEnchantment.AddShadowEnchantmentGreater();
                 Spells.MagicalTailSpells.AddNewMagicalTailSpells();
 
                 MythicAbilities.ImpossibleSpeed.AddImpossibleSpeed();

--- a/TabletopTweaks/NewContent/Spells/MagicalTailSpells.cs
+++ b/TabletopTweaks/NewContent/Spells/MagicalTailSpells.cs
@@ -1,0 +1,53 @@
+﻿using Kingmaker.Blueprints;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
+using Kingmaker.UnitLogic.Abilities.Components;
+using TabletopTweaks.Config;
+using TabletopTweaks.Extensions;
+using TabletopTweaks.Utilities;
+
+namespace TabletopTweaks.NewContent.Spells {
+    class MagicalTailSpells {
+        public static void AddNewMagicalTailSpells() {
+
+            BlueprintAbility sleepKitsune = Resources.GetBlueprint<BlueprintAbility>("f8a32c60ae1f878408b525bb967ef48c");
+            BlueprintAbility hideousLaughter = Resources.GetBlueprint<BlueprintAbility>("fd4d9fd7f87575d47aafe2a64a6e2d8d");
+
+            BlueprintAbility deepSlumberKitsune = Resources.GetBlueprint<BlueprintAbility>("2bc8d4bb8baa23a4b84ef34945d13733");
+            BlueprintAbility heroism = Resources.GetBlueprint<BlueprintAbility>("5ab0d42fb68c9e34abae4921822b9d63");
+
+            var hideousLaughterKitsune = Helpers.CreateCopy(hideousLaughter, bp => {
+                bp.AssetGuid = ModSettings.Blueprints.GetGUID("HideousLaughterKitsune");
+            });
+
+            hideousLaughterKitsune.RemoveComponents<AbilityResourceLogic>();
+            hideousLaughterKitsune.AddComponent<AbilityResourceLogic>(c => {
+                c.Amount = sleepKitsune.GetComponent<AbilityResourceLogic>().Amount;
+                c.CostIsCustom = sleepKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
+                c.m_IsSpendResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
+                c.m_RequiredResource = sleepKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
+                c.name = sleepKitsune.GetComponent<AbilityResourceLogic>().name;
+                c.ResourceCostDecreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
+                c.ResourceCostIncreasingFacts = sleepKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
+            });
+
+            Resources.AddBlueprint(hideousLaughterKitsune);
+
+            var heroismKitsune = Helpers.CreateCopy(heroism, bp => {
+                bp.AssetGuid = ModSettings.Blueprints.GetGUID("HeroismKitsune");
+            });
+
+            heroismKitsune.RemoveComponents<AbilityResourceLogic>();
+            heroismKitsune.AddComponent<AbilityResourceLogic>(c => {
+                c.Amount = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().Amount;
+                c.CostIsCustom = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().CostIsCustom;
+                c.m_IsSpendResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_IsSpendResource;
+                c.m_RequiredResource = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().m_RequiredResource;
+                c.name = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().name;
+                c.ResourceCostDecreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts;
+                c.ResourceCostIncreasingFacts = deepSlumberKitsune.GetComponent<AbilityResourceLogic>().ResourceCostIncreasingFacts;
+            });
+
+            Resources.AddBlueprint(heroismKitsune);
+        }
+    }
+}

--- a/TabletopTweaks/TabletopTweaks.csproj
+++ b/TabletopTweaks/TabletopTweaks.csproj
@@ -329,6 +329,7 @@
     <Compile Include="NewContent\ArcanistExploits\QuickStudy.cs" />
     <Compile Include="NewContent\Feats\AnimalAlly.cs" />
     <Compile Include="NewContent\Feats\CelestialServant.cs" />
+    <Compile Include="NewContent\Spells\MagicalTailSpells.cs" />
     <Compile Include="NewContent\Feats\DervishDance.cs" />
     <Compile Include="NewContent\Feats\ExtraArcana.cs" />
     <Compile Include="NewContent\Feats\ExtraArcanistExploit.cs" />


### PR DESCRIPTION
Magical Tail 2 is Hideous Laughter
Magical Tail 5 is Heroism

Sleep spells are useless when you get them, this changes the spells to more useful ones.