### PR TITLE
Don't recommend Erastil's Blessing for Zen Archers

### DIFF
--- a/TabletopTweaks/NewContent/Feats/ErastilsBlessing.cs
+++ b/TabletopTweaks/NewContent/Feats/ErastilsBlessing.cs
@@ -59,6 +59,11 @@ namespace TabletopTweaks.NewContent.Feats {
                     c.Stat = StatType.Wisdom;
                     c.MinimalValue = 16;
                 }));
+                bp.AddComponent(Helpers.Create<RecommendationNoFeatFromGroup(c => {
+                    c.m_Features = new BlueprintUnitFactReference[] {
+                        ZenArcherZenArcheryFeature.ToReference<BlueprintUnitFactReference>()
+                    };
+                }));
                 bp.AddComponent<FeatureTagsComponent>(c => {
                     c.FeatureTags = FeatureTag.Attack | FeatureTag.Ranged;
                 });


### PR DESCRIPTION
Erastil's Blessing and Zen Archery are mechanically identical features. Added a RecommendationNoFeatFromGroup so that Erastil's Blessing is not recommended for characters with Zen Archery.

Untested, since I haven't set up a dev build yet.